### PR TITLE
Create ndmi

### DIFF
--- a/sentinel-2/ndmi
+++ b/sentinel-2/ndmi
@@ -1,0 +1,32 @@
+//
+// Normalized Difference 820/1600 Normalized Difference Moisture Index (abbrv. NDMI)
+//
+// General formula: (820nm - 1600nm) / (820nm + 1600nm)
+//
+// URL https://www.indexdatabase.de/db/si-single.php?sensor_id=96&rsindex_id=56
+//
+
+let index = (B08 - B11) / (B08 + B11);
+let min = -0.89;
+let max = 0.89;
+let zero = 0.0;
+
+// colorBlend will return a color when the index is between min and max and white when it is less than min.
+// To see black when it is more than max, uncomment the last line of colorBlend.
+// The min/max values were computed automatically and may be poorly specified, feel free to change them to tweak the displayed range.
+// This index crosses zero, so a diverging color map is used. To tweak the value of the break in the color map, change the variable 'zero'.
+
+let underflow_color = [1, 1, 1];
+let low_color = [208/255, 88/255, 126/255];
+let high_color = [241/255, 234/255, 200/255];
+let zero_color = [0, 147/255, 146/255];
+let overflow_color = [0, 0, 0];
+
+return colorBlend(index, [min, min, zero, max],
+[
+	underflow_color,
+	low_color,
+	zero_color, // divergent step at zero
+	high_color,
+	//overflow_color // uncomment to see overflows
+]);


### PR DESCRIPTION
Normalized Differenced Moisture Index used top determine if irrigation has taken place in areas where there has been no recent rain events. If NDMI is above 0, depending on the land and canopy cover, it is possible to determine if irrigation has taken place. Using this Index with Sentinel-2 bands 08 and 11 it is possible to identify this with 10 m. resolution. The logic used for this was taken from this article from [This article.](https://www.agricolus.com/en/indici-vegetazione-ndvi-ndmi-istruzioni-luso/)

By following that logic, and knowing land uses within an area as well as climatic conditions, it was possible to difference between productive and non-productive areas first, and then see how this Index is reflected in different agricultural parcels. Some of them showed high levels of NDMI in summer moths after several weeks without rain. The only source of irrigation water was from an aquifer below. Some of the parcels do have water concessions and others not, so it was possible to identify illegal water use. On the other hand, it was possible to identify if a parcel in which the crop is known (e.g. citrus crops) irrigation is being effective or not during the crucial growing season in summer, as it is possible to find if some parts of the farm are being under or over irrigated. 
