### PR TITLE
Correct typo in band names

### DIFF
--- a/sentinel-2/composites/README.md
+++ b/sentinel-2/composites/README.md
@@ -65,7 +65,7 @@ Custom script: **return [B12, B11, B02];**
 
 ### RGB (4,3,1)
 
-Custom script: **return [B12, B11, B02];**
+Custom script: **return [B04, B03, B01];**
 
 ![Bathymetric sample](fig/fig6.png)
 


### PR DESCRIPTION
There was a typo in the Bathimetric product description: the band names were wrong