### PR TITLE
Changed filterScenes to use preProcessScenes

### DIFF
--- a/sentinel-2/vegetation_condition_index/script.js
+++ b/sentinel-2/vegetation_condition_index/script.js
@@ -2,9 +2,9 @@
 function setup() {
   return {
     input: ["B04", "B08"],
-    output: { bands: 1},
+    output: { bands: 1 },
     mosaicking: "ORBIT"
-  }  
+  }
 }
 
 const msInDay = 24 * 60 * 60 * 1000;
@@ -14,25 +14,27 @@ const toleranceMs = toleranceDays * msInDay;
 
 var metadata = undefined;
 
-function filterScenes(scenes, inputMetadata) {
-  scenes = scenes.sort((s1, s2) => s2.date - s1.date);
-  const observed = scenes[0].date;
+function preProcessScenes(collections) {
+  var scenes = collections.scenes.orbits
+
+  const observed = new Date(scenes[0].dateFrom)
   var newScenes = [scenes[0]];
-  for (var historical = observed - msInYear; historical >= inputMetadata.from - toleranceMs; historical -= msInYear) {
+  for (var historical = observed - msInYear; historical >= new Date(collections.from) - toleranceMs; historical -= msInYear) {
     newScenes.push(findClosest(scenes, historical));
   }
   newScenes = newScenes.filter(scene => scene != null);
   metadata = {
     observed: observed.toISOString(),
-    historical: newScenes.slice(1).map(scene => scene.date.toISOString())
+    historical: newScenes.slice(1).map(scene => new Date(scene.dateFrom).toISOString())
   }
-  return newScenes;
+  collections.scenes.orbits = newScenes
+  return collections
 }
 
 function findClosest(scenes, date) {
   var closestDt = toleranceMs + 1, closestScene = null;
   for (var i = 0; i < scenes.length; i++) {
-    const dt = Math.abs(scenes[i].date - date);
+    const dt = Math.abs(new Date(scenes[i].dateFrom) - date);
     if (dt < closestDt) {
       closestDt = dt;
       closestScene = scenes[i];

--- a/sentinel-2/vegetation_condition_index/script.js
+++ b/sentinel-2/vegetation_condition_index/script.js
@@ -16,7 +16,7 @@ var metadata = undefined;
 
 function preProcessScenes(collections) {
   var scenes = collections.scenes.orbits;
-  scenes = scenes.sort((s1, s2) => s2.date - s1.date);
+  scenes = scenes.sort((s1, s2) => s2.dateFrom - s1.dateFrom);
   const observed = new Date(scenes[0].dateFrom)
   var newScenes = [scenes[0]];
   for (var historical = observed - msInYear; historical >= new Date(collections.from) - toleranceMs; historical -= msInYear) {

--- a/sentinel-2/vegetation_condition_index/script.js
+++ b/sentinel-2/vegetation_condition_index/script.js
@@ -15,8 +15,8 @@ const toleranceMs = toleranceDays * msInDay;
 var metadata = undefined;
 
 function preProcessScenes(collections) {
-  var scenes = collections.scenes.orbits
-
+  var scenes = collections.scenes.orbits;
+  scenes = scenes.sort((s1, s2) => s2.date - s1.date);
   const observed = new Date(scenes[0].dateFrom)
   var newScenes = [scenes[0]];
   for (var historical = observed - msInYear; historical >= new Date(collections.from) - toleranceMs; historical -= msInYear) {

--- a/sentinel-2/vegetation_productivity_indicator/script.js
+++ b/sentinel-2/vegetation_productivity_indicator/script.js
@@ -15,8 +15,8 @@ const toleranceMs = toleranceDays * msInDay;
 var metadata = undefined;
 
 function preProcessScenes(collections) {
-  var scenes = collections.scenes.orbits
-
+  var scenes = collections.scenes.orbits;
+  scenes = scenes.sort((s1, s2) => s2.dateFrom - s1.dateFrom);
   const observed = new Date(scenes[0].dateFrom)
   var newScenes = [scenes[0]];
   for (var historical = observed - msInYear; historical >= new Date(collections.from) - toleranceMs; historical -= msInYear) {


### PR DESCRIPTION
This changes two scripts to use the now reccommended `preProcessScenes` function instead of `filterScenes`.

The preProcessing is the same for both.

Here is the comparison for the new and old scripts showing that the output is still the same:

[VCI](https://apps.sentinel-hub.com/eo-browser/?sharedPinsListId=827554a5-62b3-4403-bcd4-df891a5449e1), 
[VPI](https://apps.sentinel-hub.com/eo-browser/?sharedPinsListId=cd507494-407b-4c90-862e-8dab6c92b6d5)