### PR TITLE
Remove paragraph with script details for Soil Water Content and Land Surface Temperature

### DIFF
--- a/planetary-variables/land-surface-temperature/land-surface-temperature-visualization/index.md
+++ b/planetary-variables/land-surface-temperature/land-surface-temperature-visualization/index.md
@@ -20,8 +20,6 @@ Land Surface Temperature (LST) is the thermodynamic temperature of Earth’s sur
 
 Planet's LST product provides near real-time measurements twice a day at 1:30 and 13:30 solar local time and at spatial resolutions of 100 m and 1000 m. It is unhindered by clouds and has a long and consistent data record of more than 20 years. Please check [here](https://docs.sentinel-hub.com/api/latest/data/planet/land-surface-temp/#available-bands) for a list of available bands.
 
-This script provides 4 outputs. The `default` output is for visualizing LST in EO Browser. The `index` output is the actual value of the LST. The `eobrowserStats` and `dataMask` outputs are configured to activate the statistical features in EO Browser.
-
 ## Description of representative images
 
 Land Surface Temperature (100 m) on Oct 8, 2023 at 13:30 near Hanover, Germany.

--- a/planetary-variables/soil-water-content/soil-water-content-visualization/index.md
+++ b/planetary-variables/soil-water-content/soil-water-content-visualization/index.md
@@ -20,8 +20,6 @@ Soil Water Content (SWC) measures the amount of water in a unit volume of soil, 
 
 Planet's SWC product provides near-daily measurements at spatial resolutions of 100 m and 1000 m. It is unhindered by clouds and has a long and consistent data record of more than 20 years. Please check [here](https://docs.sentinel-hub.com/api/latest/data/planet/soil-water-content/#available-bands) for a list of available bands.
 
-This script provides 4 outputs. The `default` output is for visualizing SWC in EO Browser. The `index` output is the actual value of the SWC. The `eobrowserStats` and `dataMask` outputs are configured to activate the statistical features in EO Browser.
-
 ## Description of representative images
 
 Soil Water Content (L band 100 m) on Sep 30th, 2023 near Hanover, Germany.


### PR DESCRIPTION
Two more scripts were added in #294 while the paragraph only applies to one of the scripts. Removing the paragraph is also consistent with Crop Biomass and Forest Carbon Diligence.