### PR TITLE
Fixed temporal aggregation and error handling on SH

### DIFF
--- a/planetary-variables/land-surface-temperature/land-surface-temperature-anomaly/index.md
+++ b/planetary-variables/land-surface-temperature/land-surface-temperature-anomaly/index.md
@@ -43,6 +43,8 @@ _Please note_: The date that is compared to the reference period is always the m
 
 The reference period represents which dates get included for each year and is determined by the variable `toleranceDays` in the evalscript. This variable determines how many days adjacent to the selected day are included in the calculation. If the day for which an anomaly is computed is the 10th of January 2024 and `toleranceDays` is 0, only data in previous years that are also exactly on the 10th of January will be considered. If `toleranceDays` is 1, for each year in the reference period, one day before and after the 10th of January will also be considered and included in the calculation.
 
+If multiple values are available in a year, they will be averaged to form a yearly average. This average will then be used for the anomaly calculation. This is done to avoid bias, which would happen if one year has many more acquisitions available than other years.
+
 ### Visualization
 
 In the visualization script you can modify the color scale by changing the variables `vmin` and `vmax`. Those are the maximum and minimum values of the color ramp. If the anomaly is only very slight, you might want to change `vmin` and `vmax` to lower values to be able to see slight differences better.

--- a/planetary-variables/land-surface-temperature/land-surface-temperature-anomaly/raw.js
+++ b/planetary-variables/land-surface-temperature/land-surface-temperature-anomaly/raw.js
@@ -36,22 +36,33 @@ function sortDatesDescending(d1, d2) {
     return date2 - date1;
 }
 
+var obsPerYear = [0];
 function preProcessScenes(collections) {
     let scenes = collections.scenes.tiles.filter(function (tile) {
         return tile.dataPath.includes("T" + sensingTime);
     });
     // sort
+    if (scenes.length == 0) {
+        return collections;
+    }
     scenes = scenes.sort(sortDatesDescending);
     let newScenes = [];
     // convert first scene to day of year
     const observed = new Date(scenes[0].date);
     const obsMs = datetimeToYearEpoch(observed);
+    var year = 0;
     for (let i = 0; i < scenes.length; i++) {
         let currentDate = new Date(scenes[i].date);
         let sceneMs = datetimeToYearEpoch(currentDate);
         let dt = relDiff(obsMs, sceneMs);
         if (dt <= toleranceMs) {
             newScenes.push(scenes[i]);
+            obsPerYear[year]++;
+        } else {
+            if (obsPerYear[year] != 0) {
+                year++;
+                obsPerYear[year] = 0;
+            }
         }
     }
 
@@ -89,11 +100,28 @@ function std(array, mean) {
 }
 
 function evaluatePixel(samples) {
+    // Return transparent, if no value for most recent image
+    if (samples.length == 0) return [NODATA];
+    if (!samples[0].dataMask) return [NODATA];
     const values = [];
-    for (let i = samples.length; i--; ) {
-        if (samples[i].dataMask) {
-            values.push(samples[i][band]);
+    var yearIndex = 0;
+    for (let i = 0; i < obsPerYear.length; i++) {
+        let obsInYear = obsPerYear[i];
+        if (obsInYear == 0) continue;
+        let validObsInYear = 0;
+        var yearSum = 0;
+        for (let j = 0; j < obsInYear; j++) {
+            var currentIndex = yearIndex + j;
+            if (samples[currentIndex].dataMask) {
+                yearSum += samples[currentIndex][band];
+                validObsInYear++;
+            }
         }
+        if (validObsInYear) {
+            const yearMean = yearSum / validObsInYear;
+            values.push(yearMean);
+        }
+        yearIndex += obsInYear;
     }
     if (values.length === 0) return [NODATA];
     const valsMean = mean(values);

--- a/planetary-variables/land-surface-temperature/land-surface-temperature-anomaly/script.js
+++ b/planetary-variables/land-surface-temperature/land-surface-temperature-anomaly/script.js
@@ -62,22 +62,33 @@ function sortDatesDescending(d1, d2) {
     return date2 - date1;
 }
 
+var obsPerYear = [0];
 function preProcessScenes(collections) {
     let scenes = collections.scenes.tiles.filter(function (tile) {
         return tile.dataPath.includes("T" + sensingTime);
     });
     // sort
+    if (scenes.length == 0) {
+        return collections;
+    }
     scenes = scenes.sort(sortDatesDescending);
     let newScenes = [];
     // convert first scene to day of year
     const observed = new Date(scenes[0].date);
     const obsMs = datetimeToYearEpoch(observed);
+    var year = 0;
     for (let i = 0; i < scenes.length; i++) {
         let currentDate = new Date(scenes[i].date);
         let sceneMs = datetimeToYearEpoch(currentDate);
         let dt = relDiff(obsMs, sceneMs);
         if (dt <= toleranceMs) {
             newScenes.push(scenes[i]);
+            obsPerYear[year]++;
+        } else {
+            if (obsPerYear[year] != 0) {
+                year++;
+                obsPerYear[year] = 0;
+            }
         }
     }
 
@@ -115,11 +126,28 @@ function std(array, mean) {
 }
 
 function evaluatePixel(samples) {
+    // Return transparent, if no value for most recent image
+    if (samples.length == 0) return [NODATA];
+    if (!samples[0].dataMask) return [NODATA];
     const values = [];
-    for (let i = samples.length; i--; ) {
-        if (samples[i].dataMask) {
-            values.push(samples[i][band]);
+    var yearIndex = 0;
+    for (let i = 0; i < obsPerYear.length; i++) {
+        let obsInYear = obsPerYear[i];
+        if (obsInYear == 0) continue;
+        let validObsInYear = 0;
+        var yearSum = 0;
+        for (let j = 0; j < obsInYear; j++) {
+            var currentIndex = yearIndex + j;
+            if (samples[currentIndex].dataMask) {
+                yearSum += samples[currentIndex][band];
+                validObsInYear++;
+            }
         }
+        if (validObsInYear) {
+            const yearMean = yearSum / validObsInYear;
+            values.push(yearMean);
+        }
+        yearIndex += obsInYear;
     }
     if (values.length === 0) return [0, 0, 0, 0];
     const valsMean = mean(values);

--- a/planetary-variables/soil-water-content/soil-water-content-anomaly/index.md
+++ b/planetary-variables/soil-water-content/soil-water-content-anomaly/index.md
@@ -43,6 +43,8 @@ _Please note_: The date that is compared to the reference period is always the m
 
 The reference period represents which dates get included for each year and is determined by the variable `toleranceDays` in the evalscript. This variable determines how many days adjacent to the selected day are included in the calculation. If the day for which an anomaly is computed is the 10th of January 2024 and `toleranceDays` is 0, only data in previous years that are also exactly on the 10th of January will be considered. If `toleranceDays` is 1, for each year in the reference period, one day before and after the 10th of January will also be considered and included in the calculation.
 
+If multiple values are available in a year, they will be averaged to form a yearly average. This average will then be used for the anomaly calculation. This is done to avoid bias, which would happen if one year has many more acquisitions available than other years.
+
 ### Visualization
 
 In the visualization script you can modify the color scale by changing the variables `vmin` and `vmax`. Those are the maximum and minimum values of the color ramp. If the anomaly is only very slight, you might want to change `vmin` and `vmax` to lower values to be able to see slight differences better.

--- a/planetary-variables/soil-water-content/soil-water-content-anomaly/raw.js
+++ b/planetary-variables/soil-water-content/soil-water-content-anomaly/raw.js
@@ -1,8 +1,8 @@
 // tolerance in either direction, so i.e. +- 5 days
 const toleranceDays = 1;
 
-const NODATA = NaN;
 const band = "SWC";
+const NODATA = NaN;
 
 function setup() {
     return {
@@ -34,20 +34,31 @@ function sortDatesDescending(d1, d2) {
     return date2 - date1;
 }
 
+var obsPerYear = [0];
 function preProcessScenes(collections) {
     // sort
     let scenes = collections.scenes.orbits;
+    if (scenes.length == 0) {
+        return collections;
+    }
     scenes = scenes.sort(sortDatesDescending);
     let newScenes = [];
     // convert first scene to day of year
     const observed = new Date(scenes[0].dateFrom);
     const obsMs = datetimeToYearEpoch(observed);
+    var year = 0;
     for (let i = 0; i < scenes.length; i++) {
         let currentDate = new Date(scenes[i].dateFrom);
         let sceneMs = datetimeToYearEpoch(currentDate);
         let dt = relDiff(obsMs, sceneMs);
         if (dt <= toleranceMs) {
             newScenes.push(scenes[i]);
+            obsPerYear[year]++;
+        } else {
+            if (obsPerYear[year] != 0) {
+                year++;
+                obsPerYear[year] = 0;
+            }
         }
     }
 
@@ -85,11 +96,28 @@ function std(array, mean) {
 }
 
 function evaluatePixel(samples) {
+    // Return transparent, if no value for most recent image
+    if (samples.length == 0) return [NODATA];
+    if (!samples[0].dataMask) return [NODATA];
     const values = [];
-    for (let i = samples.length; i--; ) {
-        if (samples[i].dataMask) {
-            values.push(samples[i][band]);
+    var yearIndex = 0;
+    for (let i = 0; i < obsPerYear.length; i++) {
+        let obsInYear = obsPerYear[i];
+        if (obsInYear == 0) continue;
+        let validObsInYear = 0;
+        var yearSum = 0;
+        for (let j = 0; j < obsInYear; j++) {
+            var currentIndex = yearIndex + j;
+            if (samples[currentIndex].dataMask) {
+                yearSum += samples[currentIndex][band];
+                validObsInYear++;
+            }
         }
+        if (validObsInYear) {
+            const yearMean = yearSum / validObsInYear;
+            values.push(yearMean);
+        }
+        yearIndex += obsInYear;
     }
     if (values.length === 0) return [NODATA];
     const valsMean = mean(values);


### PR DESCRIPTION
This fixes two issues with the scripts:

1. On EOB if tiles have no acquisitions at all there were warnings that `scenes[0].date` is undefined. There are now checks if there are no elements in scenes (`scenes.length == 0`)

2. If a tolerance was set, all available values were added, this lead to a biased calculation for years with more acquisitions. Now the behaviour is so, that a mean is calculated per year and the climatology is then calculated from the yearly mean.

