### PR TITLE
Added examples to planetscope scripts

### DIFF
--- a/planet_scope/false_color/README.md
+++ b/planet_scope/false_color/README.md
@@ -5,12 +5,22 @@ grand_parent: Planet
 layout: script
 permalink: /planet_scope/false_color/
 nav_exclude: true
+examples:
+- zoom: '16'
+  lat: '-32.10671'
+  lng: '116.00704'
+  datasetId: 'ccb1f8f0-e5bf-4c31-afe5-d8803bcbde2a'
+  fromTime: '2023-04-19T00:00:00.000Z'
+  toTime: '2023-04-19T23:59:59.999Z'
+  platform:
+  - EOB
+  evalscripturl: https://custom-scripts.sentinel-hub.com/custom-scripts/planet_scope/false_color/script.js
+  additionalQueryParams: 
+  - - themeId
+    - PLANET_SANDBOX
 ---
 
-
-## Evaluate and visualize
-
-As PlanetScope is commercial data, brought into Sentinel Hub as Bring Your Own Data, direct EO Browser links are not possible due to the personalized data credentials. 
+The example data is using Planet Sandox data. This data is restricted to Sentinel Hub users with active paid plans. If you are already a Planet Customer, see [here](https://community.planet.com/sentinel-hub-81/access-new-tools-for-analyzing-your-planet-data-on-sentinel-hub-732) on how to get access.
 
 ## General description
 

--- a/planet_scope/green_city/README.md
+++ b/planet_scope/green_city/README.md
@@ -5,12 +5,22 @@ grand_parent: Planet
 layout: script
 permalink: /planet_scope/green_city/
 nav_exclude: true
+examples:
+- zoom: '16'
+  lat: '-32.10671'
+  lng: '116.00704'
+  datasetId: 'ccb1f8f0-e5bf-4c31-afe5-d8803bcbde2a'
+  fromTime: '2023-04-19T00:00:00.000Z'
+  toTime: '2023-04-19T23:59:59.999Z'
+  platform:
+  - EOB
+  evalscripturl: https://custom-scripts.sentinel-hub.com/custom-scripts/planet_scope/green_city/script.js
+  additionalQueryParams: 
+  - - themeId
+    - PLANET_SANDBOX
 ---
 
-
-## Evaluate and visualize
-
-As PlanetScope is commercial data, brought into Sentinel Hub as Bring Your Own Data, direct EO Browser links are not possible due to the personalized data credentials. 
+The example data is using Planet Sandox data. This data is restricted to Sentinel Hub users with active paid plans. If you are already a Planet Customer, see [here](https://community.planet.com/sentinel-hub-81/access-new-tools-for-analyzing-your-planet-data-on-sentinel-hub-732) on how to get access.
 
 ## General description of the script
 

--- a/planet_scope/ndci/README.md
+++ b/planet_scope/ndci/README.md
@@ -8,7 +8,22 @@ nav_exclude: true
 scripts:
     - [Visualization, script.js]
     - [EO Browser, eob.js]
+examples:
+- zoom: '16'
+  lat: '-32.10671'
+  lng: '116.00704'
+  datasetId: 'ccb1f8f0-e5bf-4c31-afe5-d8803bcbde2a'
+  fromTime: '2023-04-19T00:00:00.000Z'
+  toTime: '2023-04-19T23:59:59.999Z'
+  platform:
+  - EOB
+  evalscripturl: https://custom-scripts.sentinel-hub.com/custom-scripts/planet_scope/ndci/eob.js
+  additionalQueryParams: 
+  - - themeId
+    - PLANET_SANDBOX
 ---
+
+The example data is using Planet Sandox data. This data is restricted to Sentinel Hub users with active paid plans. If you are already a Planet Customer, see [here](https://community.planet.com/sentinel-hub-81/access-new-tools-for-analyzing-your-planet-data-on-sentinel-hub-732) on how to get access.
 
 ## General description
 

--- a/planet_scope/ndre/README.md
+++ b/planet_scope/ndre/README.md
@@ -8,7 +8,22 @@ nav_exclude: true
 scripts:
     - [Visualization, script.js]
     - [EO Browser, eob.js]
+examples:
+- zoom: '16'
+  lat: '-32.10671'
+  lng: '116.00704'
+  datasetId: 'ccb1f8f0-e5bf-4c31-afe5-d8803bcbde2a'
+  fromTime: '2023-04-19T00:00:00.000Z'
+  toTime: '2023-04-19T23:59:59.999Z'
+  platform:
+  - EOB
+  evalscripturl: https://custom-scripts.sentinel-hub.com/custom-scripts/planet_scope/ndre/eob.js
+  additionalQueryParams: 
+  - - themeId
+    - PLANET_SANDBOX
 ---
+
+The example data is using Planet Sandox data. This data is restricted to Sentinel Hub users with active paid plans. If you are already a Planet Customer, see [here](https://community.planet.com/sentinel-hub-81/access-new-tools-for-analyzing-your-planet-data-on-sentinel-hub-732) on how to get access.
 
 ## General description
 

--- a/planet_scope/ndvi/README.md
+++ b/planet_scope/ndvi/README.md
@@ -8,11 +8,22 @@ nav_exclude: true
 scripts:
     - [Visualization, script.js]
     - [EO Browser, eob.js]
+examples:
+- zoom: '16'
+  lat: '-32.10671'
+  lng: '116.00704'
+  datasetId: 'ccb1f8f0-e5bf-4c31-afe5-d8803bcbde2a'
+  fromTime: '2023-04-19T00:00:00.000Z'
+  toTime: '2023-04-19T23:59:59.999Z'
+  platform:
+  - EOB
+  evalscripturl: https://custom-scripts.sentinel-hub.com/custom-scripts/planet_scope/ndvi/eob.js
+  additionalQueryParams: 
+  - - themeId
+    - PLANET_SANDBOX
 ---
 
-## Evaluate and visualize
-
-As PlanetScope is commercial data, brought into Sentinel Hub as Bring Your Own Data, direct EO Browser links are not possible due to the personalized data credentials. 
+The example data is using Planet Sandox data. This data is restricted to Sentinel Hub users with active paid plans. If you are already a Planet Customer, see [here](https://community.planet.com/sentinel-hub-81/access-new-tools-for-analyzing-your-planet-data-on-sentinel-hub-732) on how to get access.
 
 ## General description
 

--- a/planet_scope/ndwi/README.md
+++ b/planet_scope/ndwi/README.md
@@ -12,12 +12,22 @@ scripts:
   - eob.js
 - - Raw Values
   - raw.js
+examples:
+- zoom: '16'
+  lat: '-32.10671'
+  lng: '116.00704'
+  datasetId: 'ccb1f8f0-e5bf-4c31-afe5-d8803bcbde2a'
+  fromTime: '2023-04-19T00:00:00.000Z'
+  toTime: '2023-04-19T23:59:59.999Z'
+  platform:
+  - EOB
+  evalscripturl: https://custom-scripts.sentinel-hub.com/custom-scripts/planet_scope/ndwi/eob.js
+  additionalQueryParams: 
+  - - themeId
+    - PLANET_SANDBOX
 ---
 
-
-## Evaluate and visualize
-
-As PlanetScope is commercial data, brought into Sentinel Hub as Bring Your Own Data, direct EO Browser links are not possible due to the personalized data credentials. 
+The example data is using Planet Sandox data. This data is restricted to Sentinel Hub users with active paid plans. If you are already a Planet Customer, see [here](https://community.planet.com/sentinel-hub-81/access-new-tools-for-analyzing-your-planet-data-on-sentinel-hub-732) on how to get access.
 
 ## General description of the script
 

--- a/planet_scope/true_color/README.md
+++ b/planet_scope/true_color/README.md
@@ -5,12 +5,22 @@ grand_parent: Planet
 layout: script
 permalink: /planet_scope/true_color/
 nav_exclude: true
+examples:
+- zoom: '16'
+  lat: '-32.10671'
+  lng: '116.00704'
+  datasetId: 'ccb1f8f0-e5bf-4c31-afe5-d8803bcbde2a'
+  fromTime: '2023-04-19T00:00:00.000Z'
+  toTime: '2023-04-19T23:59:59.999Z'
+  platform:
+  - EOB
+  evalscripturl: https://custom-scripts.sentinel-hub.com/custom-scripts/planet_scope/true_color/script.js
+  additionalQueryParams: 
+  - - themeId
+    - PLANET_SANDBOX
 ---
 
-
-## Evaluate and visualize
-
-As PlanetScope is commercial data, brought into Sentinel Hub as Bring Your Own Data, direct EO Browser links are not possible due to the personalized data credentials.   
+The example data is using Planet Sandox data. This data is restricted to Sentinel Hub users with active paid plans. If you are already a Planet Customer, see [here](https://community.planet.com/sentinel-hub-81/access-new-tools-for-analyzing-your-planet-data-on-sentinel-hub-732) on how to get access.
 
 ## General description
 


### PR DESCRIPTION
This adds examples to Planet Scope products. They only work if you have access to Planet Sandbox data.

Could you just check that I put in all the links correctly?