### PR TITLE
Corrected NDMI formula: Changed SWIR band from B06 to B05

### DIFF
--- a/modis/ndmi/README.md
+++ b/modis/ndmi/README.md
@@ -23,9 +23,9 @@ NDMI is computed using the near infrared (NIR) and the short wave infrared (SWIR
 
 **NDMI = (NIR - SWIR) / (NIR + SWIR)**
 
-For MODIS, the NDMI is calculated using NIR band 2 and SWIR band 6: 
+For MODIS, the NDMI is calculated using NIR band 2 and SWIR band 5: 
 
-**NDMI = (B02 - B06) / (B02 + B06)**
+**NDMI = (B02 - B05) / (B02 + B05)**
 
 {: .note}
 


### PR DESCRIPTION
This pull request corrects the NDMI formula in the MODIS NDMI script. 

Based on Gao (1996) and the MODIS band specifications, the correct SWIR band for NDMI is **B05 (1.24 µm)**, not **B06 (1.64 µm)**.  This correction ensures that the script aligns with the original index definition and the correct MODIS band usage.

Refs:
- Original paper by Gao (1996): https://doi.org/10.1016/S0034-4257(96)00067-3
- MODIS band specifications: https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/modis/
- also see Index DataBase: https://www.indexdatabase.de/db/i-single.php?id=60