### PR TITLE
Corrected NDMI formula: Changed SWIR band from B06 to B05

### DIFF
--- a/sentinel-2/ndmi/README.md
+++ b/sentinel-2/ndmi/README.md
@@ -42,7 +42,7 @@ Sentinel-2 NDMI = **(B08 - B11) / (B08 + B11)**
 
 [Landsat 8 NDMI](https://custom-scripts.sentinel-hub.com/landsat-8/ndmi/#) = **(B05 - B06) / (B05 + B06)**
 
-[MODIS NDMI](https://custom-scripts.sentinel-hub.com/modis/ndmi/) = **(B02 - B06) / (B02 + B06)**
+[MODIS NDMI](https://custom-scripts.sentinel-hub.com/modis/ndmi/) = **(B02 - B05) / (B02 + B05)**
 
 {: .note}
 


### PR DESCRIPTION
This pull request corrects the NDMI formula in the MODIS NDMI script.  Based on Gao (1996) and the MODIS band specifications, the correct SWIR band for NDMI is B05 (1.24 µm), not B06 (1.64 µm). This update ensures consistency with the original index definition.