### PR TITLE
fix case of nir band for PlanetScope NDVI

### DIFF
--- a/planet/planetscope/ndvi/eob.js
+++ b/planet/planetscope/ndvi/eob.js
@@ -3,7 +3,7 @@
 
 function setup() {
   return {
-    input: ["NIR", "red", "clear", "dataMask"],
+    input: ["nir", "red", "clear", "dataMask"],
     output: [
       { id: "default", bands: 4 },
       { id: "index", bands: 1, sampleType: "FLOAT32" },
@@ -276,7 +276,7 @@ const colorRamp = [
 let viz = new ColorRampVisualizer(colorRamp);
 
 function evaluatePixel(sample) {
-  let ndvi = index(sample.NIR, sample.red);
+  let ndvi = index(sample.nir, sample.red);
   const minIndex = 0;
   const maxIndex = 1;
   let visVal = null;

--- a/planet/planetscope/ndvi/raw.js
+++ b/planet/planetscope/ndvi/raw.js
@@ -3,7 +3,7 @@
 
 function setup() {
   return {
-    input: ["NIR", "red", "dataMask"],
+    input: ["nir", "red", "dataMask"],
     output: {
       bands: 4,
     },
@@ -11,5 +11,5 @@ function setup() {
 }
 
 function evaluatePixel(sample) {
-  return [index(sample.NIR, sample.red)];
+  return [index(sample.nir, sample.red)];
 }

--- a/planet/planetscope/ndvi/script.js
+++ b/planet/planetscope/ndvi/script.js
@@ -3,7 +3,7 @@
 
 function setup() {
   return {
-    input: ["NIR", "red", "dataMask"],
+    input: ["nir", "red", "dataMask"],
     output: {
       bands: 4,
     },
@@ -273,7 +273,7 @@ const colorRamp = [
 let viz = new ColorRampVisualizer(colorRamp);
 
 function evaluatePixel(sample) {
-  let ndvi = index(sample.NIR, sample.red);
+  let ndvi = index(sample.nir, sample.red);
   const minIndex = 0;
   const maxIndex = 1;
   let visVal = null;


### PR DESCRIPTION
the current NDVI planetscope script is broken, tested both on sandbox collection and planet order

`Collection 'byoc-28eef896-9632-4546-a99e-cea34d74b21e' has no band 'NIR'.` 


`Failed to evaluate script! undefined:2: SyntaxError: Unexpected string Collection 'byoc-28eef896-9632-4546-a99e-cea34d74b21e' has no band 'NIR'. ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`