### PR TITLE
Agents guide followup - now in root folder and with more detailed evalscript structure guide

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "context": {
+    "fileName": ["AGENTS.md", "GEMINI.md"]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,9 +299,16 @@ These keep scripts fast and cheap, especially across many or large requests:
   they cost anything.
 - **Data fusion** — V3 only; `input` becomes a list of `{datasource, bands}`, and you access each source
   via `samples.<id>` (e.g. `samples.S2L2A[0].B04`). Standard datasource ids:
-  `S2L1C, S2L2A, S1GRD, S3SLSTR, S3OLCI, S5PL2, L8L1C, DEM, MODIS`. These belong in the
+  `S2L1C, S2L2A, S1GRD, S3SLSTR, S3OLCI, S5PL2, L8L1C, DEM`. These belong in the
   [`data-fusion`](/data-fusion) collection, and the example needs a data-fusion datasource setup rather
   than a single `datasetId`.
+- **Data fusion with BYOC collections** — anything outside that list, most CLMS products included, is
+  served as **BYOC** and needs its Collection ID (a UUID) plus type `BYOC` in the datasource setup; it
+  will not appear in the Copernicus Browser dataset list until you add it. The evalscript itself still
+  refers to the alias you give the source (`samples.MY_ALIAS`), never the UUID. Collection IDs live on
+  each product's own page under
+  [Sentinel Hub data collections](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Data.html)
+  — the index page carries none, so navigate down to the leaf product page.
 
 ## 8. Submitting a pull request
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,9 @@ A folder `<collection>/<slug>/` containing:
 
 …plus **one link line** added to the collection's index page, `<collection>/<collection>.md`.
 
-Copying the [example folder](/contribute/example) is the easiest starting point. If your page should
-offer several evalscript variants (for example a visualization plus a raw-values version), copy
-[example-multiple-scripts](/contribute/example-multiple-scripts) instead and see the `scripts:` field
+Copying the [example folder](/contribute/example) is the easiest starting point. One script with
+several outputs (§2) covers almost every case; only when a folder holds genuinely different products
+does it need [example-multiple-scripts](/contribute/example-multiple-scripts) and the `scripts:` field
 in §3.
 
 ## 1. Gather the inputs
@@ -59,24 +59,38 @@ in §3.
 
 ## 2. Anatomy of an evalscript
 
-Every script has the same shape. Start from this skeleton:
+Every script has the same shape. Start from this skeleton — one file, several outputs, which is the
+form to prefer:
 
 ```javascript
 //VERSION=3
 
 function setup() {
   return {
-    input: ["B04", "B08", "dataMask"],        // only the bands you actually use
-    output: { bands: 4, sampleType: "AUTO" }, // R, G, B, alpha
-    // mosaicking: "ORBIT",                   // multi-temporal scripts only
+    input: ["B04", "B08", "dataMask"],   // only the bands you actually use
+    output: [
+      { id: "default", bands: 4 },                              // R, G, B, alpha
+      { id: "index", bands: 1, sampleType: "FLOAT32" },         // histogram
+      { id: "browserStats", bands: 1, sampleType: "FLOAT32" },  // time series
+      { id: "dataMask", bands: 1 },                             // 1 = valid pixel
+    ],
+    // mosaicking: "ORBIT",              // multi-temporal scripts only
   };
 }
 
 function evaluatePixel(sample) {
   const ndvi = (sample.B08 - sample.B04) / (sample.B08 + sample.B04);
-  return [ndvi, ndvi, ndvi, sample.dataMask];
+  return {
+    default: [ndvi, ndvi, ndvi, sample.dataMask],
+    index: [ndvi],
+    browserStats: [ndvi],
+    dataMask: [sample.dataMask],
+  };
 }
 ```
+
+A visualization-only script can drop everything but `default` and return a plain array instead of an
+object. Everything else stays the same.
 
 - **`setup()`** declares which bands you request and the shape of the result.
 - **`evaluatePixel()`** holds the actual formula and runs once per pixel. Bands arrive as
@@ -87,11 +101,7 @@ function evaluatePixel(sample) {
 
 ### Outputs
 
-The `default` output is what gets drawn on the map: **3 values (R, G, B) or 4 (R, G, B, alpha)**. With
-`sampleType: "AUTO"` each is 0–1 and is mapped onto 0–255, values outside the range being clamped.
-
-To support the Copernicus Browser **Statistical Analysis** panel, declare extra named outputs. The
-names are exact:
+**Prefer one script with several outputs over several script files.** The four names are exact:
 
 | output id | bands | sampleType | purpose |
 |---|---|---|---|
@@ -99,6 +109,11 @@ names are exact:
 | `index` | 1 | `FLOAT32` | raw value — drives the histogram |
 | `browserStats` | 1 | `FLOAT32` | raw value — drives the time series (`NaN` where masked) |
 | `dataMask` | 1 | | 1 = valid pixel, 0 = no data |
+
+`default` is what gets drawn on the map. With the default `sampleType: "AUTO"` its values are 0–1,
+mapped onto 0–255 and clamped outside that range. The other three feed the Copernicus Browser
+**Statistical Analysis** panel — one script then serves the map, the histogram and the time series,
+with no duplicated copy of the formula to keep in sync.
 
 Use **`browserStats`** in new scripts. The older `eobrowserStats` still works and is what the 46
 existing scripts in this repository use — the name dates from EO Browser, which has been discontinued
@@ -178,20 +193,27 @@ examples:
 ---
 ```
 
-**Several scripts on one page.** If the folder holds more than one evalscript, list them with a
-`scripts:` field (added before `examples:`), and the page renders one tab per variant:
+**Several scripts on one page.** Reach for this only when the folder holds genuinely *different
+products* — different source datasets, or different temporal aggregations. Do **not** split a script
+into separate visualization / raw-value / per-browser files: use the multiple outputs in §2 instead,
+so there is one formula to maintain rather than three copies that drift apart. Many older pages carry
+an `eob.js` alongside `script.js` because EO Browser and Copernicus Browser needed different cloud
+masking (s2cloudless vs `SCL`); that is history, not a pattern to copy.
+
+When you do need it, list the files with a `scripts:` field before `examples:`, and the page renders
+one tab per entry:
 
 ```yaml
 scripts:
-  - [Visualization, script.js]
-  - [EO Browser, eob.js]
-  - [Raw Values, raw.js]
+  - [Copernicus DEM, script.js]
+  - [Mapzen DEM, mapzen.js]
 ```
 
 Each entry is `[<label>, <filename>]`, the first tab is the one shown by default, and every file must
-sit in the same folder as the page. Without a `scripts:` field the layout falls back to including a
-file named exactly `script.js`. The "Evaluate and Visualize" links are built separately from
-`evalscripturl` in `examples`, so point that at whichever variant the browser should open. See
+sit in the same folder as the page. The equivalent block form (`- - Copernicus DEM` on its own line)
+is used by many existing pages and is equally valid. Without a `scripts:` field the layout falls back
+to including a file named exactly `script.js`. The "Evaluate and Visualize" links are built separately
+from `evalscripturl` in `examples`, so point that at whichever variant the browser should open. See
 [example-multiple-scripts](/contribute/example-multiple-scripts) for a working page.
 
 Body, in this order:
@@ -242,6 +264,8 @@ file, and take the `parent` / `grand_parent` values from a sibling script in the
   `{ input, output }`, and an `evaluatePixel()` — and is valid JavaScript. Adding the `//VERSION=3`
   line to a V1/V2 script does not satisfy this.
 - The main evalscript is named `script.js`, unless the page lists its files explicitly in `scripts:`.
+- Raw values and statistics come from extra outputs on one script (§2), not from a separate `raw.js`
+  or a per-browser variant.
 - The page file (`README.md` or `index.md`) has `layout: script` and `nav_exclude: true` in its front
   matter.
 - `permalink` is `/<collection>/<slug>/` **and** `evalscripturl` ends with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,11 +106,12 @@ names are exact:
 |---|---|---|---|
 | `default` | 3 or 4 | `AUTO` | R, G, B (+ alpha) shown on the map |
 | `index` | 1 | `FLOAT32` | raw value — drives the histogram |
-| `eobrowserStats` | 1 | `FLOAT32` | raw value — drives the time series (`NaN` where masked) |
+| `browserStats` | 1 | `FLOAT32` | raw value — drives the time series (`NaN` where masked) |
 | `dataMask` | 1 | | 1 = valid pixel, 0 = no data |
 
-Use **`eobrowserStats`**, not `browserStats`: the CDSE FAQ shows the latter, but all 46 scripts in this
-repository use the former.
+Use **`browserStats`** in new scripts. The older `eobrowserStats` still works and is what the 46
+existing scripts in this repository use — the name dates from EO Browser, which has been discontinued
+in favour of Copernicus Browser. There is no need to go back and rename working scripts.
 
 ### `evaluatePixel` parameters
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,19 +13,11 @@ This page helps you use an AI coding assistant — or work by hand — to add a 
 repository quickly and correctly. It complements the [Contribute](/contribute) page by spelling out the
 conventions and pitfalls that are easy to miss.
 
-It is **tool-neutral**. `AGENTS.md` is an [open, cross-vendor format](https://agents.md/) for
-instructing coding agents, and this file sits in the repository root where those tools look for it, so
-most of them — Codex, Cursor, Copilot's coding agent, Windsurf, Devin, Zed, Junie and others — pick it
-up with no setup. Two assistants read a different filename, and this repository ships a two-line shim
-for each so they work out of the box too:
-
-| Assistant | Reads | Shim in this repository |
-|---|---|---|
-| Claude Code | `CLAUDE.md` | root `CLAUDE.md` imports this file with `@AGENTS.md` |
-| Gemini CLI | `GEMINI.md` | `.gemini/settings.json` sets `context.fileName` to `AGENTS.md` |
-
-Aider users should add `read: AGENTS.md` to their own `.aider.conf.yml`. Nothing below is specific to
-any one assistant, and every checklist is equally useful for a contribution made by hand.
+It is **tool-neutral**. `AGENTS.md` is an [open, cross-vendor format](https://agents.md/) that most
+coding assistants read automatically from the repository root. Two need pointing at it, and this
+repository ships a shim for each: `CLAUDE.md` imports this file with `@AGENTS.md` for Claude Code, and
+`.gemini/settings.json` sets `context.fileName` for Gemini CLI. Aider users add `read: AGENTS.md` to
+their own `.aider.conf.yml`. Nothing below is assistant-specific — every checklist works by hand too.
 
 <details markdown="block">
   <summary>Table of contents</summary>
@@ -37,8 +29,8 @@ any one assistant, and every checklist is equally useful for a contribution made
 
 A folder `<collection>/<slug>/` containing:
 
-- `script.js` — the evalscript. Version 3 is a **structure**, not just a marker: the file starts with
-  `//VERSION=3` **and** defines a `setup()` returning `{ input, output }` **and** an `evaluatePixel()`.
+- `script.js` — the evalscript. It must be a real V3 script, not just a file starting with
+  `//VERSION=3`; see §2.
 - `README.md` **or** `index.md` — the page: Jekyll front matter + a short description (see below).
   Both names work; the `permalink` in the front matter decides the URL, not the filename. Most scripts
   use `README.md`; the templates below and the `planet` / `dem` collections use `index.md`.
@@ -60,8 +52,7 @@ in §3.
   `B10` ⇒ `landsat-8` (Landsat 8/9 OLI/TIRS).
 - **Title** (human-readable) and **slug** (`snake_case`, used as the folder name).
 - **One-line description** for the index link.
-- **The evalscript** (a V3 script: `//VERSION=3`, `setup()`, `evaluatePixel()`). Note whether it needs
-  a single page or several script variants on one page.
+- **The evalscript**, and whether it needs one page or several script variants on one page.
 - **At least one example**: `lat`, `lng`, `zoom`, `datasetId`, `fromTime`/`toTime` (an ISO day window
   over a real, mostly cloud-free acquisition), and `platform` (`EOB` and/or `CDSE`).
 - **A representative image** at `fig/fig1.<ext>`, in its original format.
@@ -157,12 +148,9 @@ ignored, so `sampleType` decides it.
 
 ### `script.js`
 
-The evalscript verbatim. It must be a genuine V3 script — first line `//VERSION=3`, a `setup()`
-returning `{ input, output }`, and an `evaluatePixel()`. Prepending the `//VERSION=3` line to a V1 or
-V2 script does not convert it; the structure has to match too.
-
-Note evalscripts are **per-pixel**: they cannot access neighbouring pixels, so they cannot measure
-neighbourhoods or cluster sizes — don't describe a script as doing spatial filtering it can't do.
+The evalscript verbatim (§2). One thing worth stating outright: evalscripts are **per-pixel** — they
+cannot access neighbouring pixels, so they cannot measure neighbourhoods or cluster sizes. Don't
+describe a script as doing spatial filtering it can't do.
 
 ### `README.md` (or `index.md`)
 
@@ -245,16 +233,8 @@ mapping line to `cdse_lookup` and **call out that change in your pull request** 
 site file). You can read the real CDSE dataset id straight from a Copernicus Browser URL's
 `&datasetId=` parameter.
 
-Common tokens (always verify against the live `_layouts/script.html`, which is the source of truth):
-
-| collection | parent / grand_parent | EO Browser token | CDSE dataset id |
-|---|---|---|---|
-| `sentinel-2`  | Sentinel-2 / Sentinel | `S2L2A`, `S2L1C` | `S2_L2A_CDAS`, `S2_L1C_CDAS` |
-| `sentinel-1`  | Sentinel-1 / Sentinel | `S1_AWS_IW_VVVH`, `S1_AWS_EW_HHHV` | `S1_CDAS_IW_VVVH`, `S1_CDAS_EW_HHHV` |
-| `sentinel-3`  | Sentinel-3 / Sentinel | `S3SLSTR`, `S3OLCI` | `S3SLSTR_CDAS`, `S3OLCI_CDAS` |
-| `sentinel-5p` | Sentinel-5P / Sentinel | `S5_NO2`, `S5_O3`, … | `S5_NO2_CDAS`, `S5_O3_CDAS`, … |
-| `landsat-8`   | Landsat 8 / Landsat | `AWS_LOTL1`, `AWS_LOTL2` | `CDAS_L8_L9_LOTL1` |
-| `dem`         | DEM | `DEM_MAPZEN` | `DEM_COPERNICUS_30_CDAS` |
+No token list is reproduced here, because it would rot: read the tokens from `cdse_lookup` in that
+file, and take the `parent` / `grand_parent` values from a sibling script in the same collection.
 
 ## 5. Validation checklist
 
@@ -298,9 +278,6 @@ These keep scripts fast and cheap, especially across many or large requests:
   `S2L1C, S2L2A, S1GRD, S3SLSTR, S3OLCI, S5PL2, L8L1C, DEM, MODIS`. These belong in the
   [`data-fusion`](/data-fusion) collection, and the example needs a data-fusion datasource setup rather
   than a single `datasetId`.
-
-Further reading: Sentinel Hub's *Multi-temporal processing*, *Custom scripts: faster, cheaper, better*,
-and *Data fusion: combine satellite datasets* articles.
 
 ## 8. Submitting a pull request
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,18 @@ This page helps you use an AI coding assistant — or work by hand — to add a 
 repository quickly and correctly. It complements the [Contribute](/contribute) page by spelling out the
 conventions and pitfalls that are easy to miss.
 
-It is **tool-neutral**. The page lives at `AGENTS.md` in the repository root, which is where coding
-assistants look for repository instructions, so most of them pick it up automatically. Claude Code is
-an exception: it reads `CLAUDE.md`, so the root `CLAUDE.md` in this repository simply imports this
-file with `@AGENTS.md` ([why](https://code.claude.com/docs/en/memory)). Nothing below is specific to
+It is **tool-neutral**. `AGENTS.md` is an [open, cross-vendor format](https://agents.md/) for
+instructing coding agents, and this file sits in the repository root where those tools look for it, so
+most of them — Codex, Cursor, Copilot's coding agent, Windsurf, Devin, Zed, Junie and others — pick it
+up with no setup. Two assistants read a different filename, and this repository ships a two-line shim
+for each so they work out of the box too:
+
+| Assistant | Reads | Shim in this repository |
+|---|---|---|
+| Claude Code | `CLAUDE.md` | root `CLAUDE.md` imports this file with `@AGENTS.md` |
+| Gemini CLI | `GEMINI.md` | `.gemini/settings.json` sets `context.fileName` to `AGENTS.md` |
+
+Aider users should add `read: AGENTS.md` to their own `.aider.conf.yml`. Nothing below is specific to
 any one assistant, and every checklist is equally useful for a contribution made by hand.
 
 <details markdown="block">

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ repository ships a shim for each: `CLAUDE.md` imports this file with `@AGENTS.md
 `.gemini/settings.json` sets `context.fileName` for Gemini CLI. Aider users add `read: AGENTS.md` to
 their own `.aider.conf.yml`. Nothing below is assistant-specific — every checklist works by hand too.
 
+**Writing evalscripts outside this repository?** This file is useful on its own. Copy it into the root
+of your own project as `AGENTS.md` and your assistant will pick it up there the same way (for Claude
+Code, add a `CLAUDE.md` containing `@AGENTS.md` alongside it, exactly as above). §2 and §6 are the
+parts that apply to any evalscript; the rest describes how contributions to *this* repository are laid
+out.
+
 <details markdown="block">
   <summary>Table of contents</summary>
 - TOC

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ These keep scripts fast and cheap, especially across many or large requests:
 - Prefer a smaller `sampleType` (`UINT8` / `UINT16`) when full float precision isn't needed; digital
   numbers carry the same information as reflectance for normalized-difference indices.
 - Compute indices/functions **conditionally** (only in the branch that needs them).
-- Use `filterScenes` to drop unneeded scenes from a time range.
+- Use `preProcessScenes` to drop unneeded scenes from a time range before they cost anything.
 - Reuse `viz.process` / `viz.processList` and predefined products where available; delete unused code.
 
 ## 7. Advanced script types

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ A folder `<collection>/<slug>/` containing:
 Copying the [example folder](/contribute/example) is the easiest starting point. If your page should
 offer several evalscript variants (for example a visualization plus a raw-values version), copy
 [example-multiple-scripts](/contribute/example-multiple-scripts) instead and see the `scripts:` field
-in §2.
+in §3.
 
 ## 1. Gather the inputs
 
@@ -66,7 +66,93 @@ in §2.
   over a real, mostly cloud-free acquisition), and `platform` (`EOB` and/or `CDSE`).
 - **A representative image** at `fig/fig1.<ext>`, in its original format.
 
-## 2. Scaffold the files
+## 2. Anatomy of an evalscript
+
+Every script has the same shape. Start from this skeleton:
+
+```javascript
+//VERSION=3
+
+function setup() {
+  return {
+    input: ["B04", "B08", "dataMask"],        // only the bands you actually use
+    output: { bands: 4, sampleType: "AUTO" }, // R, G, B, alpha
+    // mosaicking: "ORBIT",                   // multi-temporal scripts only
+  };
+}
+
+function evaluatePixel(sample) {
+  const ndvi = (sample.B08 - sample.B04) / (sample.B08 + sample.B04);
+  return [ndvi, ndvi, ndvi, sample.dataMask];
+}
+```
+
+- **`setup()`** declares which bands you request and the shape of the result.
+- **`evaluatePixel()`** holds the actual formula and runs once per pixel. Bands arrive as
+  `sample.<band>` (`sample.B04`); with `mosaicking` set they become `samples[i].<band>`.
+- **`mosaicking`** — `"SIMPLE"` (the default, one scene), `"ORBIT"` or `"TILE"` — is what makes a
+  script [multi-temporal](https://docs.sentinel-hub.com/api/latest/evalscript/v3/#mosaicking). The
+  string form is the repo convention (69 scripts) over the `Mosaicking.ORBIT` enum (19).
+
+### Outputs
+
+The `default` output is what gets drawn on the map: **3 values (R, G, B) or 4 (R, G, B, alpha)**. With
+`sampleType: "AUTO"` each is 0–1 and is mapped onto 0–255, values outside the range being clamped.
+
+To support the Copernicus Browser **Statistical Analysis** panel, declare extra named outputs. The
+names are exact:
+
+| output id | bands | sampleType | purpose |
+|---|---|---|---|
+| `default` | 3 or 4 | `AUTO` | R, G, B (+ alpha) shown on the map |
+| `index` | 1 | `FLOAT32` | raw value — drives the histogram |
+| `eobrowserStats` | 1 | `FLOAT32` | raw value — drives the time series (`NaN` where masked) |
+| `dataMask` | 1 | | 1 = valid pixel, 0 = no data |
+
+Use **`eobrowserStats`**, not `browserStats`: the CDSE FAQ shows the latter, but all 46 scripts in this
+repository use the former.
+
+### `evaluatePixel` parameters
+
+The full signature is `evaluatePixel(samples, scenes, inputMetadata, customData, outputMetadata)`.
+Most scripts only ever need the first. The rest are
+[documented here](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Evalscript/Functions.html#parameters):
+
+| parameter | contains | use it for |
+|---|---|---|
+| `samples` | band values — an object under `SIMPLE`, an **array** under `ORBIT`/`TILE` | everything |
+| `scenes` | per-scene metadata: `scenes.tiles[i].cloudCoverage`, `.date`, `scenes.orbits[i].dateFrom` | skipping or weighting cloudy scenes |
+| `inputMetadata` | `serviceVersion`, `normalizationFactor` (`REFLECTANCE = DN × factor`) | converting DN to reflectance |
+| `customData` | reserved for future use | nothing today |
+| `outputMetadata` | write `.userData` to return JSON beside the raster | recording which acquisitions contributed |
+
+### Colour helpers
+
+`new ColorRampVisualizer(ramp)` interpolates between stops; `new ColorMapVisualizer(pairs)` is a
+discrete step lookup with no blending. Both are **classes** — construct once at the top of the script,
+then call `.process(value)` per pixel, which returns a normalized RGB triplet. Colours are hex
+(`0xff0000`) or 0–1 triplets, never 0–255. Stock ramps come from the static factories
+(`ColorRampVisualizer.createBlueRed(min, max)` and friends). Full list of
+[utilities and visualizers](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Evalscript/Utilities.html).
+
+### Through OGC services (WMS/WCS/WMTS)
+
+If the script will be served through an OGC layer rather than the Processing API,
+[three things change](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Evalscript/Functions.html#ogc-services-specifics):
+only the `default` output comes back (no extra outputs, no JSON metadata); `TRANSPARENCY` and
+`BGCOLOR` are ignored, so handle transparency with `dataMask`; and the bit depth in `FORMAT` is
+ignored, so `sampleType` decides it.
+
+### Going further
+
+| Topic | Reference |
+|---|---|
+| V3 reference — `setup`, outputs, mosaicking | [docs.sentinel-hub.com](https://docs.sentinel-hub.com/api/latest/evalscript/v3/) |
+| `preProcessScenes` — drop scenes before processing | [Functions](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Evalscript/Functions.html#preprocessscenes) |
+| `updateOutput` — band count decided at runtime | [Functions](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Evalscript/Functions.html#updateoutput) |
+| Multi-temporal `for` loop over `samples` (mean NDVI) | [Examples](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Evalscript/Examples.html#calculating-the-mean-ndvi-value-during-a-given-time-period) |
+
+## 3. Scaffold the files
 
 ### `script.js`
 
@@ -144,7 +230,7 @@ Add to `<collection>/<collection>.md`, under an existing heading, matching the s
 - [<Title>](/<collection>/<slug>) - <one-line description>
 ```
 
-## 3. The examples block and the CDSE lookup
+## 4. The examples block and the CDSE lookup
 
 The website turns the `examples` block into "open in browser" buttons, and the two platforms differ:
 
@@ -169,7 +255,7 @@ Common tokens (always verify against the live `_layouts/script.html`, which is t
 | `landsat-8`   | Landsat 8 / Landsat | `AWS_LOTL1`, `AWS_LOTL2` | `CDAS_L8_L9_LOTL1` |
 | `dem`         | DEM | `DEM_MAPZEN` | `DEM_COPERNICUS_30_CDAS` |
 
-## 4. Validation checklist
+## 5. Validation checklist
 
 - Every evalscript in the folder is a real V3 script — first line `//VERSION=3`, a `setup()` returning
   `{ input, output }`, and an `evaluatePixel()` — and is valid JavaScript. Adding the `//VERSION=3`
@@ -188,7 +274,7 @@ Common tokens (always verify against the live `_layouts/script.html`, which is t
 - The index link line is added under an existing heading.
 - Contributions inherit the repository's **CC BY-SA 4.0** license (credit authors in the index line).
 
-## 5. Evalscript quality checklist
+## 6. Evalscript quality checklist
 
 These keep scripts fast and cheap, especially across many or large requests:
 
@@ -201,11 +287,11 @@ These keep scripts fast and cheap, especially across many or large requests:
 - Use `filterScenes` to drop unneeded scenes from a time range.
 - Reuse `viz.process` / `viz.processList` and predefined products where available; delete unused code.
 
-## 6. Advanced script types
+## 7. Advanced script types
 
-- **Multi-temporal** — set `mosaicking` in `setup` (`SIMPLE` / `ORBIT` / `TILE`);
-  `evaluatePixel(samples, …)` receives `samples` as an array of scenes; use
-  `preProcessScenes` / `filterScenes` to select acquisitions.
+- **Multi-temporal** — set `mosaicking` in `setup` and loop over the `samples` array in
+  `evaluatePixel`; see §2 for both, and use `preProcessScenes` to drop unwanted acquisitions before
+  they cost anything.
 - **Data fusion** — V3 only; `input` becomes a list of `{datasource, bands}`, and you access each source
   via `samples.<id>` (e.g. `samples.S2L2A[0].B04`). Standard datasource ids:
   `S2L1C, S2L2A, S1GRD, S3SLSTR, S3OLCI, S5PL2, L8L1C, DEM, MODIS`. These belong in the
@@ -215,7 +301,7 @@ These keep scripts fast and cheap, especially across many or large requests:
 Further reading: Sentinel Hub's *Multi-temporal processing*, *Custom scripts: faster, cheaper, better*,
 and *Data fusion: combine satellite datasets* articles.
 
-## 7. Submitting a pull request
+## 8. Submitting a pull request
 
 - **One script per pull request** keeps reviews small and independently mergeable.
 - Fork the repository, create a branch (e.g. `add-<slug>`), and commit your `<collection>/<slug>/`


### PR DESCRIPTION
This is a follow-up to https://github.com/sentinel-hub/custom-scripts/pull/368
Some of my commits to that were made after it was merged, and also commented there - sorry for the confusion.
- We extended some of the review fixes: we have .gemini/settings.json to point Gemini at agents.md
- New Section 2 - anatomy of an evalscript: this is the main addition, actually explaining what goes into an evalscript - with a collection of links.
- we are now recommending multi-output scripts instead of multiple scripts in the same folder
- browserStats instead of eoBrowserStats

Corrections:
- modis removed from the data fusion data source list as it is no longer in the custom scripts repo
- added pointer to BYOC collection IDs

I tried to shorten but it is still very long :~)